### PR TITLE
remove css that overwrites button styles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
 	"require": {
 		"mustache/mustache": "^2.12.0",
-		"spatie/server-side-rendering": "^0.2.5"
+		"spatie/server-side-rendering": "^0.2.5",
+		"fedeisas/laravel-mail-css-inliner": "^2.3"
 	},
 	"require-dev": {
 		"processmaker/processmaker": "4.0.*"
@@ -32,7 +33,8 @@
 	"extra": {
 		"laravel": {
 			"providers": [
-				"ProcessMaker\\Packages\\Connectors\\Email\\PluginServiceProvider"
+				"ProcessMaker\\Packages\\Connectors\\Email\\PluginServiceProvider",
+				"Fedeisas\\LaravelMailCssInliner\\LaravelMailCssInlinerServiceProvider"
 			]
 		}
 	},

--- a/src/PluginServiceProvider.php
+++ b/src/PluginServiceProvider.php
@@ -66,6 +66,11 @@ class PluginServiceProvider extends ServiceProvider
         // Register a seeder that will be executed in php artisan db:seed
         $this->registerSeeder(EmailSendSeeder::class);
 
+        // Tell css inliner to use core's app.css
+        config([
+            'css-inliner.css-files' => [public_path('css/app.css')]
+        ]);
+
         // Complete the connector boot
         $this->completePluginBoot();
     }

--- a/src/views/layout.blade.php
+++ b/src/views/layout.blade.php
@@ -35,27 +35,6 @@
       color: black;
     }
 
-    a.btn {
-      color: white;
-    }
-
-    .btn {
-      padding: 10px;
-      margin-bottom: 10px;
-      border-radius: 5px;
-      text-decoration: none;
-      display: inline-block;
-    }
-
-    .btn:hover {
-      color: white;
-      background-color: #0069d9;
-    }
-
-    .btn-primary {
-      background-color: #3397e1;
-    }
-
     a.text-light {
       text-decoration: none;
       color: #f8f9fa;


### PR DESCRIPTION
This PR removes CSS that overwrites the button styles in the email template for the actions by email package.

Dependent PR:
package-actions-by-email: [feature/button ui update.](https://github.com/ProcessMaker/package-actions-by-email/pull/21)