### PR TITLE
Restore crown on send email

### DIFF
--- a/resources/js/connectors/email/send/component.vue
+++ b/resources/js/connectors/email/send/component.vue
@@ -1,8 +1,3 @@
-<template>
-  <div>
-  </div>
-</template>
-
 <script>
 import icon from './marker.svg';
 


### PR DESCRIPTION
Extend task template instead of using a custom empty template.